### PR TITLE
fix: remove handling of NO_PROXY

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import * as tunnel from "tunnel";
 
-const { PROXY_HOST, PROXY_PORT, PROXY_USERNAME, PROXY_PASSWORD, NO_PROXY } = process.env;
+const { PROXY_HOST, PROXY_PORT, PROXY_USERNAME, PROXY_PASSWORD } = process.env;
 
 const isProxyDefined = (): boolean => {
     return PROXY_HOST !== undefined && PROXY_PORT !== undefined;
@@ -22,7 +22,6 @@ if (isProxyDefined()) {
         proxy: {
             host: PROXY_HOST!,
             port: Number(PROXY_PORT!),
-            localAddress: NO_PROXY,
             proxyAuth: getProxyAuth(),
         },
     });

--- a/tests/praxios.test.ts
+++ b/tests/praxios.test.ts
@@ -50,4 +50,16 @@ describe("praxios", () => {
         expect(praxios).toHaveProperty("baseAxios");
         expect(praxios).toHaveProperty("tunnel");
     });
+
+    test("NO_PROXY env var is not considered in the tunnel agent", async () => {
+        process.env.PROXY_HOST = "dummy";
+        process.env.PROXY_PORT = "3128";
+        process.env.PROXY_USERNAME = "foo";
+        process.env.PROXY_PASSWORD = "bar";
+        process.env.NO_PROXY = "host1,host2";
+
+        const praxios = (await import("../src/index")).default;
+
+        expect(praxios.defaults.httpsAgent.proxyOptions.localAddress).toBeUndefined();
+    });
 });


### PR DESCRIPTION
NO_PROXY can still be used to bypass proxies for a comma-separated list of hosts but not passed to the tunnel agent

Fixes #1 